### PR TITLE
Use simple-httpfs instead of the original httpfs filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,18 @@ To install HiGlass Server manually follow the steps below. Note we strongly reco
 git clone https://github.com/higlass/higlass-server && cd higlass-server
 mkvirtualenv -a $(pwd) -p $(which python3) higlass-server && workon higlass-server
 pip install --upgrade -r ./requirements.txt
-pip install --upgrade -r ./requirements-secondary.txt
 python manage.py runserver
 ```
 
 To enable the register_url api endpoint, HiGlass depends on a project called httpfs to cache external url files. Tests depend on this process running. Set it up as follows:
 ```bash
-git clone https://github.com/reservoirgenomics/httpfs.git
-pip install -r httpfs/requirements.txt
-python /internal-services/httpfs/httpfs.py </path/to/data>/https https --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296
-python /internal-services/httpfs/httpfs.py </path/to/data>/http http --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296
-python /internal-services/httpfs/httpfs.py </path/to/data>/http ftp --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296
+pip install simple-httpfs
+
+simple-httpfs.py media/http
+simple-httpfs.py media/https
 ```
+
+Or simply use `./unit_tests.sh`.
 
 ---
 

--- a/docker-context/Dockerfile
+++ b/docker-context/Dockerfile
@@ -21,9 +21,8 @@ RUN conda install --yes cython==0.25.2 numpy=1.12.0
 RUN conda install --yes --channel bioconda pysam htslib=1.3.2
 RUN pip install uwsgi==2.0.14
 
-WORKDIR /internal-services
-RUN git clone https://github.com/reservoirgenomics/httpfs.git
-RUN pip install -r httpfs/requirements.txt
+RUN pip install simple-httpfs
+
 ENV HTTPFS_HTTP_DIR /data/media/http
 ENV HTTPFS_HTTPS_DIR /data/media/https
 ENV HTTPFS_FTP_DIR /data/media/ftp

--- a/docker-context/Dockerfile
+++ b/docker-context/Dockerfile
@@ -21,7 +21,7 @@ RUN conda install --yes cython==0.25.2 numpy=1.12.0
 RUN conda install --yes --channel bioconda pysam htslib=1.3.2
 RUN pip install uwsgi==2.0.14
 
-RUN pip install simple-httpfs>=0.1.2
+RUN pip install simple-httpfs>=0.1.3
 
 ENV HTTPFS_HTTP_DIR /data/media/http
 ENV HTTPFS_HTTPS_DIR /data/media/https

--- a/docker-context/Dockerfile
+++ b/docker-context/Dockerfile
@@ -21,7 +21,7 @@ RUN conda install --yes cython==0.25.2 numpy=1.12.0
 RUN conda install --yes --channel bioconda pysam htslib=1.3.2
 RUN pip install uwsgi==2.0.14
 
-RUN pip install simple-httpfs
+RUN pip install simple-httpfs>=0.1.2
 
 ENV HTTPFS_HTTP_DIR /data/media/http
 ENV HTTPFS_HTTPS_DIR /data/media/https

--- a/docker-context/httpfs.sh
+++ b/docker-context/httpfs.sh
@@ -4,6 +4,6 @@ mkdir -p $HTTPFS_HTTP_DIR
 mkdir -p $HTTPFS_HTTPS_DIR
 mkdir -p $HTTPFS_FTP_DIR
 
-simple-httpfs.py $HTTPFS_HTTPS_DIR https --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296
-simple-httpfs.py $HTTPFS_HTTP_DIR http --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296
-simple-httpfs.py $HTTPFS_FTP_DIR ftp --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296
+simple-httpfs.py $HTTPFS_HTTPS_DIR --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296
+simple-httpfs.py $HTTPFS_HTTP_DIR --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296
+simple-httpfs.py $HTTPFS_FTP_DIR --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296

--- a/docker-context/httpfs.sh
+++ b/docker-context/httpfs.sh
@@ -4,6 +4,6 @@ mkdir -p $HTTPFS_HTTP_DIR
 mkdir -p $HTTPFS_HTTPS_DIR
 mkdir -p $HTTPFS_FTP_DIR
 
-python /internal-services/httpfs/httpfs.py $HTTPFS_HTTPS_DIR https --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296
-python /internal-services/httpfs/httpfs.py $HTTPFS_HTTP_DIR http --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296
-python /internal-services/httpfs/httpfs.py $HTTPFS_FTP_DIR ftp --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296
+simple-httpfs.py $HTTPFS_HTTPS_DIR https --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296
+simple-httpfs.py $HTTPFS_HTTP_DIR http --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296
+simple-httpfs.py $HTTPFS_FTP_DIR ftp --lru-capacity 1000 --disk-cache-dir /data/disk-cache --disk-cache-size 4294967296

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ slugid==1.0.7
 bumpversion==0.5.3
 redis==2.10.5
 clodius>=0.10.0.rc2
-simple-httpfs>=0.1.1
+simple-httpfs>=0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ slugid==1.0.7
 bumpversion==0.5.3
 redis==2.10.5
 clodius>=0.10.0.rc2
-simple-httpfs>=0.1.2
+simple-httpfs>=0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ slugid==1.0.7
 bumpversion==0.5.3
 redis==2.10.5
 clodius>=0.10.0.rc2
-simple-httpfs>=0.1.2
+simple-httpfs>=0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ slugid==1.0.7
 bumpversion==0.5.3
 redis==2.10.5
 clodius>=0.10.0.rc2
+simple-httpfs>=0.1.2

--- a/tilesets/views.py
+++ b/tilesets/views.py
@@ -702,7 +702,7 @@ def register_url(request):
     '''
     body = json.loads(request.body.decode('utf8'))
 
-    url = "%s.." % body.get('fileurl', '').replace('http:', 'http').replace('https:', 'https').replace('ftp:', 'ftp')
+    url = "%s" % body.get('fileurl', '').replace('http:/', 'http').replace('https:/', 'https').replace('ftp:/', 'ftp')
     media_base_path = op.realpath(hss.MEDIA_ROOT)
 
     # validate the url to ensure we didn't get garbage

--- a/tilesets/views.py
+++ b/tilesets/views.py
@@ -702,7 +702,7 @@ def register_url(request):
     '''
     body = json.loads(request.body.decode('utf8'))
 
-    url = "%s" % body.get('fileurl', '').replace('http:/', 'http').replace('https:/', 'https').replace('ftp:/', 'ftp')
+    url = "%s.." % body.get('fileurl', '').replace('http:/', 'http').replace('https:/', 'https').replace('ftp:/', 'ftp')
     media_base_path = op.realpath(hss.MEDIA_ROOT)
 
     # validate the url to ensure we didn't get garbage

--- a/unit_tests.sh
+++ b/unit_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+umount media/http
+umount media/https
+
+simple-httpfs.py media/http
+simple-httpfs.py media/https
+
+python manage.py test tilesets.tests.FileUploadTest --failfast
+
+#python manage.py test tilesets --failfast


### PR DESCRIPTION
Use the new versioned [simple-httpfs](https://github.com/higlass/simple-httpfs) client instead of reservoirgenomics/httpfs.

The command format changes ever so slightly but it's otherwise functionally the same.