### PR TITLE
Flekschas/fragments api mcool v2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v1.11.1
 v1.11.0
 
 - Link unfurling endpoints /link and /thumbnail
+- **BREAKING CHANGE:** You need at least Python `v3.6` or higher
 
 v1.10.2
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _Note: that the HiGlass Server itself only provides an API, and does not serve a
 
 **Prerequirements**:
 
-- Python v3
+- Python `>=v3.6`
 
 ### Docker
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,35 @@
+name: higlass-server
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+
+dependencies:
+  - python>=3.7
+  - numba
+  - Pillow
+  - pip
+  - pip:
+    - pybbi==0.2.0
+    - bumpversion==0.5.3
+    - CacheControl==0.12.4
+    - cooler==0.8.6
+    - django-cors-headers==3.0.2
+    - django-guardian==1.5.1
+    - django-rest-swagger==2.2.0
+    - django==2.1.5
+    - djangorestframework==3.7.3
+    - h5py==2.6.0
+    - numpy
+    - pandas==0.23.4
+    - pybase64==0.2.1
+    - pyBigWig==0.3.2
+    - redis==2.10.5
+    - requests==2.20.0
+    - scikit-learn
+    - slugid==1.0.7
+    - bumpversion==0.5.3
+    - redis==2.10.5
+    - clodius==0.11.2
+    - simple-httpfs>=0.1.3
+    - pyppeteer>=0.0.25

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
 #### test requirements
 asynctest>=0.13.0
-pyppeteer>=0.0.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pybbi==0.2.0
 bumpversion==0.5.3
 CacheControl==0.12.4
-cooler==0.8.5
+cooler==0.8.6
 django-cors-headers==3.0.2
 django-guardian==1.5.1
 django-rest-swagger==2.2.0
@@ -20,6 +20,6 @@ scikit-learn==0.19.1
 slugid==1.0.7
 bumpversion==0.5.3
 redis==2.10.5
-clodius==0.10.8
+clodius==0.11.2
 simple-httpfs>=0.1.3
 pyppeteer>=0.0.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ bumpversion==0.5.3
 redis==2.10.5
 clodius==0.10.8
 simple-httpfs>=0.1.3
+pyppeteer>=0.0.25


### PR DESCRIPTION
## Description

> What was changed in this pull request?

1. Added support for `.mcool` v2 for the fragments API
2. I added `environment.yml` to easily create a conda env because installing all the dependencies via virtualenv was too complicated (i.e., multiple libraries didn't compile).
3. Highlighted that Python 3.6 is required since `v1.11.0`
4. Moved `pyppeteer` to `requirements.txt` as it's a hard requirement
5. Updated clodius and cooler

> Why is it necessary?

Currently, only v1 `.mcool`s are supported

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [x] Updated CHANGELOG.md
