### PR TITLE
Add migration step to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To install HiGlass Server manually follow the steps below. Note we strongly reco
 git clone https://github.com/higlass/higlass-server && cd higlass-server
 mkvirtualenv -a $(pwd) -p $(which python3) higlass-server && workon higlass-server
 pip install --upgrade -r ./requirements.txt
+python manage.py migrate
 python manage.py runserver
 ```
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

The line `python manage.py migrate` was added to the manual installation instructions.

> Why is it necessary?

Before migrating, visiting `http://localhost:8000/api/v1/tilesets/` returns a 500 error.

## Checklist

- [ ] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Updated CHANGELOG.md
