### PR TITLE
Update readme installation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Future version
 
 - Added support for bigBed files
+- Update readme installation instructions and troubleshooting instructions for macOS 10.15
 
 v1.13.0
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ To enable the register_url api endpoint, HiGlass depends on a project called htt
 ```bash
 pip install simple-httpfs
 
-simple-httpfs.py media/http
-simple-httpfs.py media/https
+mkdir -p media/http
+mkdir -p media/https
+simple-httpfs media/http
+simple-httpfs media/https
 ```
 
 Or simply use `./unit_tests.sh`.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,28 @@ docker run -d --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unc
 
 To install HiGlass Server manually follow the steps below. Note we strongly recommend to create a virtual environment using [Virtualenvwrapper](https://pypi.python.org/pypi/virtualenvwrapper) for example. Skip step 2 if you don't work with virtual environments.
 
+#### Manually with virtualenvwrapper
+
 ```bash
 git clone https://github.com/higlass/higlass-server && cd higlass-server
 mkvirtualenv -a $(pwd) -p $(which python3) higlass-server && workon higlass-server
 pip install --upgrade -r ./requirements.txt
+python manage.py runserver
+```
+
+#### Manually with conda
+
+First install the mac dependencies:
+
+- `brew install hdf5`
+- `brew install libpng`
+- `brew install jpeg`
+- [FUSE for Mac](https://osxfuse.github.io/)
+
+```
+conda env create -f environment.yml
+conda activate higlass-server
+python manage.py migrate
 python manage.py runserver
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,25 +31,22 @@ docker run -d --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unc
 
 To install HiGlass Server manually follow the steps below. Note we strongly recommend to create a virtual environment using [Virtualenvwrapper](https://pypi.python.org/pypi/virtualenvwrapper) for example. Skip step 2 if you don't work with virtual environments.
 
+```bash
+git clone https://github.com/higlass/higlass-server && cd higlass-server
+```
+
 #### Manually with virtualenvwrapper
 
 ```bash
-git clone https://github.com/higlass/higlass-server && cd higlass-server
 mkvirtualenv -a $(pwd) -p $(which python3) higlass-server && workon higlass-server
 pip install --upgrade -r ./requirements.txt
+python manage.py migrate
 python manage.py runserver
 ```
 
 #### Manually with conda
 
-First install the mac dependencies:
-
-- `brew install hdf5`
-- `brew install libpng`
-- `brew install jpeg`
-- [FUSE for Mac](https://osxfuse.github.io/)
-
-```
+```bash
 conda env create -f environment.yml
 conda activate higlass-server
 python manage.py migrate
@@ -123,6 +120,14 @@ bumpversion patch
 ## Troubleshooting
 
 **pybbi installation fails on macOS**: Check out https://github.com/nvictus/pybbi/issues/2
+
+### macOS 10.15 dependencies
+
+- `brew install hdf5`
+- `brew install libpng`
+- `brew install jpeg`
+- [FUSE for Mac](https://osxfuse.github.io/)
+
 
 ## License
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 
 dependencies:
-  - python==3.7.*
+  - python>=3.6
   - pip
   - pip:
     - pybbi==0.2.0
@@ -30,6 +30,6 @@ dependencies:
     - scikit-learn==0.19.2
     - slugid==2.0.0
     - redis==2.10.5
-    - clodius==0.11.3
+    - clodius==0.12.0
     - simple-httpfs==0.2.0
     - pyppeteer==0.0.25


### PR DESCRIPTION
## Description

What was changed in this pull request?

This pull request adds instructions for manual installation with conda, and updates the `environment.yml` file to reflect the clodius version in `requirements.txt` and sets python to version `>=3.6` which matches the python version specified in the readme. 

Also, it adds troubleshooting instructions for mac 10.15.

Why is it necessary?

@sehilyi and I both just installed `higlass-server` on brand new laptops and had to install `hdf5`, `libpng`, and `jpeg` with brew to fix pip install issues thrown by Pillow/PIL.

## Checklist

- [ ] Unit tests added or updated
- [x] Documentation added or updated
- [x] Updated CHANGELOG.md
