### PR TITLE
handle proxies in front, that do TLS termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Future version
 
 - Added support for bigBed files
 - Update readme installation instructions and troubleshooting instructions for macOS 10.15
+- Always consider proxy headers (X-Forwarded-Host, X-Forwarded-Proto) for redirect URL construction
 
 v1.13.0
 

--- a/higlass_server/settings.py
+++ b/higlass_server/settings.py
@@ -314,9 +314,13 @@ SNIPPET_IMT_MAX_DATA_DIM = get_setting('SNIPPET_IMT_MAX_DATA_DIM', 2048)
 STATIC_URL = '/hgs-static/'
 STATIC_ROOT = 'hgs-static/'
 
+# allow multiple proxies, for i.e. tls termination
+# see https://docs.djangoproject.com/en/2.2/_modules/django/http/request/
+USE_X_FORWARDED_HOST = True
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 if 'APP_BASEPATH' in os.environ:
     # https://stackoverflow.com/questions/44987110/django-in-subdirectory-admin-site-is-not-working
-    USE_X_FORWARDED_HOST = True
     FORCE_SCRIPT_NAME = os.environ['APP_BASEPATH']
     SESSION_COOKIE_PATH = os.environ['APP_BASEPATH']
     LOGIN_REDIRECT_URL = os.environ['APP_BASEPATH']


### PR DESCRIPTION
## Description

What was changed in this pull request?
Django should always consider "X-Forwarded-Host" headers, and use "X-Forwarded-Proto: https" to detect https + external hostname for URL generation in website/views.py link():
https://github.com/higlass/higlass-server/blob/develop/website/views.py#L50
Django docs:
https://github.com/django/django/blob/89032876f427a77ab4de26493190280377567d1c/django/http/request.py#L100
https://github.com/django/django/blob/89032876f427a77ab4de26493190280377567d1c/django/http/request.py#L247

Why is it necessary?
Allow to use proxy servers in front of higlass nginx that do TLS termination.

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [x] Updated CHANGELOG.md
