### PR TITLE
Fixed issue where 'error' was being set in chromsizes tileset_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.14.8
+
+- Fixed issue where 'error' was being set in chromsizes-tsv tileset_info
+
 v1.14.7
 
 - Bump Pillow
@@ -23,7 +27,7 @@ v1.14.2
 
 - Turn off thumbnail generation
 
-v1.14.*
+v1.14.\*
 
 - Added support for bigBed files
 - Update readme installation instructions and troubleshooting instructions for macOS 10.15
@@ -138,7 +142,7 @@ v1.3.0 (2017-10-21)
 v1.2.3 (2017-10-03)
 
 - Same changes as last time. They didn't actually make it into v1.2.2
-v1.2.2 (2017-10-03)
+  v1.2.2 (2017-10-03)
 
 - Fixed a bug with ignore-diags in the fragments API
 
@@ -292,8 +296,8 @@ v0.3.4
 
 v0.3.3
 
-- Added __str__ to Tileset models so that they're visible in the django
-interface
+- Added **str** to Tileset models so that they're visible in the django
+  interface
 
 v0.3.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Pillow>=9.0.0
 pybase64==0.2.1
 redis==2.10.5
 requests==2.26.0
-scikit-learn==0.19.2
+scikit-learn==1.0.2
 slugid==2.0.0
 redis==2.10.5
 clodius==0.18.0

--- a/tilesets/tests.py
+++ b/tilesets/tests.py
@@ -539,6 +539,29 @@ class MultivecTests(dt.TestCase):
 
 
 class ChromosomeSizes(dt.TestCase):
+    def test_tileset_info(self):
+        self.user1 = dcam.User.objects.create_user(
+            username='user1', password='pass'
+        )
+        upload_file = open('data/chromSizes.tsv', 'rb')
+        self.chroms = tm.Tileset.objects.create(
+            datafile=dcfu.SimpleUploadedFile(
+                upload_file.name, upload_file.read()
+            ),
+            filetype='chromsizes-tsv',
+            datatype='chromsizes',
+            coordSystem="hg19",
+            owner=self.user1,
+            uuid='cs-hg19'
+        )
+
+        ret = self.client.get(
+            '/api/v1/tileset_info/?d=cs-hg19'
+        ).json()
+
+        assert 'chromsizes' in ret['cs-hg19']
+        assert 'error' not in ret
+        
     def test_list_chromsizes(self):
         self.user1 = dcam.User.objects.create_user(
             username='user1', password='pass'

--- a/tilesets/views.py
+++ b/tilesets/views.py
@@ -651,6 +651,11 @@ def tileset_info(request):
             if 'chromsizes' in tsinfo:
                 tsinfo['chromsizes'] = [(c, int(s)) for c,s in tsinfo['chromsizes']]
             tileset_infos[tileset_uuid] = tsinfo
+        elif tileset_object.filetype == 'chromsizes-tsv':
+            chromsizes = tgt.get_chromsizes(tileset_object)
+            tileset_infos[tileset_uuid] = {
+                'chromsizes': [(c, int(s)) for c,s in chromsizes]
+            }
         elif tileset_object.filetype == 'fasta':
             chromsizes = tgt.get_chromsizes(tileset_object)
             tsinfo = hgfa.tileset_info(


### PR DESCRIPTION
## Description

What was changed in this pull request?

- Return `tileset_info` from chromsizes with out an 'error'

Why is it necessary?

- `tileset_info` endpoint was returning the erroneously returning the 'error' field in chromsizes tileset_info

Fixes #\_\_\_

## Checklist

-   [x] Unit tests added or updated
-   [x] Updated CHANGELOG.md
-   [x] Run `black .`
